### PR TITLE
fix compare date type bug

### DIFF
--- a/src/SSDTHelper/DataComparer.cs
+++ b/src/SSDTHelper/DataComparer.cs
@@ -160,7 +160,7 @@ namespace SSDTHelper
                                .Where(x => string.Compare(x["ColumnName"].ToString(), colName, true) == 0)
                                .Select(x => (SqlDbType)(int)x["ProviderType"]).FirstOrDefault();
 
-      if (providerType == SqlDbType.Date)
+      if (providerType == SqlDbType.Date && actual[colName] != DBNull.Value)
       {
         return ((DateTime)actual[colName]).ToShortDateString();
       }

--- a/src/SSDTHelperTest/DataComparerTest.cs
+++ b/src/SSDTHelperTest/DataComparerTest.cs
@@ -224,6 +224,33 @@ namespace SSDTHelperTest
       }
     }
 
+    [Test]
+    public void CompareNullValueTest()
+    {
+      var dt = SSDTHelper.ExcelReader.Read(Util.GetLocalFileFullPath("TestData.xlsx"), "NullValue");
 
+      var loader = new SSDTHelper.DataLoader();
+      loader.ConnectionString = Config.ConnectionString;
+      loader.Load(dt, true);
+
+      using (var cn = new System.Data.SqlClient.SqlConnection(Config.ConnectionString))
+      {
+        cn.Open();
+
+        // execute
+        using (var cmd = cn.CreateCommand())
+        {
+          cmd.CommandText = "SELECT Id,IntCol01,DecCol01,DateCol01,DateTimeCol01,VarCharCol01 FROM NullValue ORDER BY Id";
+          cmd.CommandType = CommandType.Text;
+          using (var dr = cmd.ExecuteReader())
+          {
+            string message;
+            var ismatch = SSDTHelper.DataComparer.IsMatch(dt, dr, out message);
+
+            Assert.AreEqual(true, ismatch, message);
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
#9 でDate型の比較を変更しましたが、テーブルから取得したDate型の値がNULLだった場合に、キャストエラーになってしまいテストがこけてしまいました。

なので、取得した値がNULLであれば日付文字列に変換しないように回避してみました。
（ついでにテストケースも追加しておきました）