### PR TITLE
fix compare number of rows expected and actual

### DIFF
--- a/src/SSDTHelper/DataComparer.cs
+++ b/src/SSDTHelper/DataComparer.cs
@@ -122,27 +122,32 @@ namespace SSDTHelper
         return false;
       }
 
+      // number of expected rows
+      var expectedRowCount = expected.Rows.Count;
+
       // content of data
       var rowindex = 0;
       while (actual.Read())
       {
-        foreach (var col in expected.Columns)
+        if(rowindex < expectedRowCount)
         {
-          var colName = ((DataColumn)col).ColumnName.ToUpper();
-          var actualValue = GetActualValue(actual, colName);
-          var expectedValue = expected.Rows[rowindex][colName];
-
-          if (actualValue.ToString() != expectedValue.ToString())
+          foreach (var col in expected.Columns)
           {
-            message = $"contents do not match: rowindex [{rowindex}] , column name [{col}] , expected [{expectedValue}], actual [{actualValue}]";
-            return false;
+            var colName = ((DataColumn)col).ColumnName.ToUpper();
+            var actualValue = GetActualValue(actual, colName);
+            var expectedValue = expected.Rows[rowindex][colName];
+
+            if (actualValue.ToString() != expectedValue.ToString())
+            {
+              message = $"contents do not match: rowindex [{rowindex}] , column name [{col}] , expected [{expectedValue}], actual [{actualValue}]";
+              return false;
+            }
           }
         }
         rowindex += 1;
       }
 
-      // numbers of rows
-      var expectedRowCount = expected.Rows.Count;
+      // numbers of actual rows
       var actualRowCount = rowindex;
       if (actualRowCount != expectedRowCount)
       {

--- a/src/SSDTHelperTest/DataComparerTest.cs
+++ b/src/SSDTHelperTest/DataComparerTest.cs
@@ -225,6 +225,77 @@ namespace SSDTHelperTest
     }
 
     [Test]
+    public void CompareUnmatchTest2()
+    {
+      var dt = SSDTHelper.ExcelReader.Read(Util.GetLocalFileFullPath("TestData.xlsx"), "People");
+
+      var loader = new SSDTHelper.DataLoader();
+      loader.ConnectionString = Config.ConnectionString;
+      loader.Load(dt, true);
+
+      using (var cn = new System.Data.SqlClient.SqlConnection(Config.ConnectionString))
+      {
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+          cmd.CommandType = CommandType.Text;
+          cmd.CommandText = @"
+            SELECT
+              Id, Name, Age 
+            FROM
+              People
+            UNION ALL
+            SELECT
+              999 as Id, 'Foo' as Name, 99 as Age";
+
+          using (var dr = cmd.ExecuteReader())
+          {
+            var message = "";
+            var ismatch = SSDTHelper.DataComparer.IsMatch(dt, dr, out message);
+
+            // Number of expected rows and actual rows is unmatch (more actual than expected)
+            Assert.AreEqual(false, ismatch);
+          }
+        }
+      }
+    }
+
+    [Test]
+    public void CompareUnmatchTest3()
+    {
+      var dt = SSDTHelper.ExcelReader.Read(Util.GetLocalFileFullPath("TestData.xlsx"), "People");
+
+      var loader = new SSDTHelper.DataLoader();
+      loader.ConnectionString = Config.ConnectionString;
+      loader.Load(dt, true);
+
+      using (var cn = new System.Data.SqlClient.SqlConnection(Config.ConnectionString))
+      {
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+          cmd.CommandType = CommandType.Text;
+          cmd.CommandText = @"
+            SELECT
+              Id, Name, Age
+            FROM
+              People
+            WHERE
+              Age > 20";
+
+          using (var dr = cmd.ExecuteReader())
+          {
+            var message = "";
+            var ismatch = SSDTHelper.DataComparer.IsMatch(dt, dr, out message);
+
+            // Number of expected rows and actual rows is unmatch (more expected than actual)
+            Assert.AreEqual(false, ismatch);
+          }
+        }
+      }
+    }
+
+    [Test]
     public void CompareNullValueTest()
     {
       var dt = SSDTHelper.ExcelReader.Read(Util.GetLocalFileFullPath("TestData.xlsx"), "NullValue");


### PR DESCRIPTION
先にexpectedの行数を取得して、actualをReadして比較する過程でインクリメントしているrowindexがexpectedの行数を超える（expected側に比較する行が無い）場合は、比較の処理をスキップしてrowindexのインクリメントだけするようにしました。
